### PR TITLE
Accomodate padding change in Products section

### DIFF
--- a/src/partials/products.html
+++ b/src/partials/products.html
@@ -64,8 +64,9 @@
         </picture>
         <h3 class="product__caption">ice cream</h3>
         <p class="product__description">
-          Our ice-cream is a fine blend of colourful unicorns’ poo grazing on a
-          rainbow. Unique flavour, unforgettable experience. Taste and fly away!
+          Our ice-cream is a&nbsp;fine blend of colourful unicorns’ poo grazing
+          on&nbsp;a&nbsp;rainbow. Unique flavour, unforgettable experience.
+          Taste and fly away!
         </p>
         <button type="button" class="circle-btn">
           <svg class="circle-btn__icon" width="11" height="10">
@@ -132,9 +133,9 @@
         </picture>
         <h3 class="product__caption">ice coffee</h3>
         <p class="product__description">
-          Cools your body temperature lower than you ever need to store a Pfizer
-          vaccine. Our coffee jab is invigorating in a big&nbsp;way. –273C° of
-          pleasure
+          Cools your body temperature lower than you ever need to&nbsp;store
+          a&nbsp;Pfizer vaccine. Our coffee jab is invigorating in
+          a&nbsp;big&nbsp;way. –273C°&nbsp;of pleasure
         </p>
         <button type="button" class="circle-btn">
           <svg class="circle-btn__icon" width="11" height="10">
@@ -202,7 +203,8 @@
         <h3 class="product__caption">milkshakes</h3>
         <p class="product__description">
           Our milkshakes are cooler than beer and longer than beard. Shake your
-          milkshake then shake your body. Or milk your buddy (if you have one)
+          milkshake then shake your body. Or&nbsp;milk your buddy (if you have
+          one)
         </p>
         <button type="button" class="circle-btn">
           <svg class="circle-btn__icon" width="11" height="10">

--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -55,6 +55,8 @@
   height: 40px;
   border-radius: 50px;
   border: none;
+  align-self: center;
+  margin-top: auto;
   background-color: $secondary-text-color;
   color: $button-right-arrow-fill;
 

--- a/src/sass/layout/_footer.scss
+++ b/src/sass/layout/_footer.scss
@@ -89,7 +89,7 @@
     content: '';
     display: block;
     position: absolute;
-    width: 100vw;
+    width: 100%;
     height: 1px;
     background: #e1e1e1;
     left: 0;

--- a/src/sass/layout/_hero.scss
+++ b/src/sass/layout/_hero.scss
@@ -9,6 +9,7 @@
     padding-top: 193px;
     padding-bottom: 160px;
     background-color: $accent-background;
+    overflow: hidden;
 
     &::after {
       content: '';

--- a/src/sass/layout/_products.scss
+++ b/src/sass/layout/_products.scss
@@ -22,6 +22,8 @@
 .product {
   width: 100%;
   position: relative;
+  display: flex;
+  flex-direction: column;
   margin-top: calc((252 * (100vw - 70px) / 249) * (113 / 249) + 31px);
   margin-bottom: 17px;
   padding: 0 40px 40px;


### PR DESCRIPTION
Выровняла курглую кнопку в "Products" по нижнему краю: теперь она не зависит от количества текста в описании. В hero поставила overflow: hidden (иначе основная картинка раздвигала правый падинг всей страницы) and в footer поменяла width: 100vw на 100%, чтобы не появлялся горизонтальный скролл в мобильном режиме